### PR TITLE
Add a radeontop window rule, and fix a bug in the fish config

### DIFF
--- a/.config/fish/functions/cat.fish
+++ b/.config/fish/functions/cat.fish
@@ -1,7 +1,7 @@
 function cat --wraps=bat --description 'alias cat=bat'
-    if type -f bat &>/dev/null
+    if type -f bat &>/dev/null; and [ -t 1 ]
         bat $argv
     else
-        cat $argv
+        command cat $argv
     end
 end

--- a/.config/hypr/theme/rules.conf
+++ b/.config/hypr/theme/rules.conf
@@ -49,6 +49,7 @@ windowrule = workspace 6, class:^(.*kdenlive.*)$
 windowrule = workspace 21 silent, class:^(.*thunderbird.*)$
 windowrule = workspace 22 silent, class:^(.*btop.*)$
 windowrule = workspace 22 silent, class:^(.*nvtop.*)$
+windowrule = workspace 22 silent, class:^(.*radeontop.*)$
 windowrule = workspace 19 silent, class:^(.*[Ss]potify.*)$|(.*tidal-hifi.*)$|(.*You[Tt]ube Music.*)$|^(.*feishin.*)$
 windowrule = workspace 20 silent, class:^(.*discord.*)$|(.*vesktop.*)$|(.*WebCord.*)$|(.*legcord.*)$
 windowrule = workspace 15, class:^(.*obsproject.*)$

--- a/.config/hypr/theme/rules.conf
+++ b/.config/hypr/theme/rules.conf
@@ -49,7 +49,6 @@ windowrule = workspace 6, class:^(.*kdenlive.*)$
 windowrule = workspace 21 silent, class:^(.*thunderbird.*)$
 windowrule = workspace 22 silent, class:^(.*btop.*)$
 windowrule = workspace 22 silent, class:^(.*nvtop.*)$
-windowrule = workspace 22 silent, class:^(.*radeontop.*)$
 windowrule = workspace 19 silent, class:^(.*[Ss]potify.*)$|(.*tidal-hifi.*)$|(.*You[Tt]ube Music.*)$|^(.*feishin.*)$
 windowrule = workspace 20 silent, class:^(.*discord.*)$|(.*vesktop.*)$|(.*WebCord.*)$|(.*legcord.*)$
 windowrule = workspace 15, class:^(.*obsproject.*)$


### PR DESCRIPTION
## 🌿 Description

First change: radeontop rule added. Radeontop is not installed in the config by default, but adding this rule makes the config more seamless. If you're on an AMD machine, you would likely want to set this rule anyway, if you are not, this rule shouldn't make a difference.

Second change: this fixes a bug in several commands which rely on the cat command within fish, most noticably tab completion for commands such as pacman failed for me. It probably fixes other problems as well, but I haven't found those.

The problem stems from the fact that the "bat" command will add its fancy padding to the text of a file, even when it is clearly not outputting to a terminal, but is being used for piping, or similar, this is problematic if we want to generically use 'bat' every time we say "cat" in fish.

This actually becomes a problem when internal fish commands, for example `/usr/share/fish/functions/__fish_print_pacman_packages.fish`, which is called by `/usr/share/fish/completions/pacman.fish` ends up using bat instead of cat for this reason.

The workaround is to simply check if stdout is in fact a terminal, and if not, just use the standard cat command, as done in this MR.

## 📝 Type of change

<!-- Please put an `x` in the boxes that apply -->

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer)
- [ ] **Other** (provide details below)

## 🔎 Checklist

<!-- Please put an `x` in the boxes that apply -->

- [x] I have read the [CONTRIBUTING](./CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My commit message follows the [commit guidelines](./COMMIT_MESSAGE_GUIDELINES.md). (unsure, the link seems broken)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added necessary comments/documentation to my code. (none, to be precise)
- [x] I have tested my code locally and it works as expected.

## 📸 Screenshots

<!-- If appropriate -->

## ✏️ Additional context

<!-- Add any other context about the pull request here -->
